### PR TITLE
Add README for OctoAcme Project Management documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,29 @@
+# OctoAcme Project Management Docs — README
+
+## Project Management Processes Overview
+
+OctoAcme uses an iterative, customer‑centric project management approach:
+
+- Project initiation: gate ideas with a Project One-pager and stakeholder alignment.
+- Planning: break work into shippable increments, define acceptance criteria, and map milestones.
+- Execution & tracking: use a project board workflow (Backlog → Ready → In Progress → In Review → QA → Done), small PRs, CI gating, daily standups, and regular demos.
+- Risk & communication: maintain a Risk Register, escalate per the defined paths, and use weekly status updates for stakeholders.
+- Release & deployment: follow pre-release checks, smoke tests, rollback plan, and an incident playbook.
+- Retrospectives & improvement: run timeboxed retros, track action items, and feed improvements back into the backlog.
+
+## Core Docs (in this folder)
+
+- octoacme-project-management-overview.md
+- octoacme-project-initiation.md
+- octoacme-project-planning.md
+- octoacme-execution-and-tracking.md
+- octoacme-risks-and-communication.md
+- octoacme-release-and-deployment.md
+- octoacme-retrospective-and-continuous-improvement.md
+- octoacme-roles-and-personas.md
+
+## How to use these docs
+
+- Link the Project One-pager and release notes from your project repository into this docs folder.
+- Keep living process docs up to date as decisions and improvements are made.
+- Add process-change requests via the `.github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml` issue template.


### PR DESCRIPTION
Introduce a README file that outlines the project management processes and provides guidance on using the documentation for the OctoAcme project. This addition enhances clarity and accessibility for users.